### PR TITLE
Bugfix terminology.service.ts

### DIFF
--- a/src/app/services/terminology.service.ts
+++ b/src/app/services/terminology.service.ts
@@ -130,8 +130,18 @@ export class TerminologyService {
     if (this.context) {
       return this.context.languageDialects;
     } else if (this.languageRefsetConcept) {
-      return this.lang + '-X-' + this.languageRefsetConcept.code
+      return toLanguageCode(this.lang, + this.languageRefsetConcept.code);
     } else return this.lang;
+  }
+
+  toLanguageCode(lang: string, langRefset: string) {
+    if (langRefset.length > 16) {
+      return `${lang}-x-sctlang-${langRefset.substring(0, 8)}-${langRefset.substring(8, 16)}-${langRefset.substring(16)}`;
+    } else if (langRefset.length > 8) {
+      return `${lang}-x-sctlang-${langRefset.substring(0, 8)}-${langRefset.substring(8)}`;
+    } else {
+      return `${lang}-x-sctlang-${langRefset}`;
+    }
   }
 
   getCodeSystems() {

--- a/src/app/services/terminology.service.ts
+++ b/src/app/services/terminology.service.ts
@@ -130,7 +130,7 @@ export class TerminologyService {
     if (this.context) {
       return this.context.languageDialects;
     } else if (this.languageRefsetConcept) {
-      return toLanguageCode(this.lang, + this.languageRefsetConcept.code);
+      return this.toLanguageCode(this.lang, this.languageRefsetConcept.code);
     } else return this.lang;
   }
 


### PR DESCRIPTION
The syntax for language references dialects is incorrect (and syntactically illegal by BCP47)

This patch uses the correct syntax.

This bug prevents use of Ontoserver with the demonstrator